### PR TITLE
Representação apenas para cadastro municipal

### DIFF
--- a/frontend/src/components/form/ProfessionalData.vue
+++ b/frontend/src/components/form/ProfessionalData.vue
@@ -412,7 +412,7 @@
                     />
                 </div>
 
-                <div class="col-12">
+                <div class="col-12" v-if="form.regional.value === 2">
                     <q-toggle
                       v-model="form.possuiRepresentacao"
                       label="Possui também alguma representação em conselho de assistência social (municipal ou estadual)?" />


### PR DESCRIPTION
SED-110 - Cadastro - Aba Representações - 1

A aba de “Representações” deveria aparecer apenas para os cadastros do âmbito de atuação municipal.